### PR TITLE
Users should accept licenses on their own

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,14 +70,14 @@ docker build --tag="$USER/splunk" .
 To manually start Splunk Enterprise container 
 
 ```bash
-docker run --hostname splunk -p 8000:8000 -d outcoldman/splunk:6.4.0
+docker run --hostname splunk -p 8000:8000 -d --env SPLUNK_START_ARGS="--accept-license" outcoldman/splunk:6.4.0
 ```
 
 This docker image has two data volumes `/opt/splunk/etc` and `/opt/splunk/var` (See [Data Store](#data-store)). To avoid losing any data when container is stopped/deleted mount these volumes from docker volume containers (see [Managing data in containers](https://docs.docker.com/userguide/dockervolumes/))
 
 ```bash
 docker run --name vsplunk -v /opt/splunk/etc -v /opt/splunk/var busybox
-docker run --hostname splunk --name splunk --volumes-from=vsplunk -p 8000:8000 -d outcoldman/splunk:6.4.0
+docker run --hostname splunk --name splunk --volumes-from=vsplunk -p 8000:8000 -d --env SPLUNK_START_ARGS="--accept-license" outcoldman/splunk:6.4.0
 ```
 
 Or if you use [docker-compose](https://docs.docker.com/compose/)
@@ -179,6 +179,9 @@ configuration files or deployment server.
         `SPLUNK_CMD_<1..30>`.
     - Example `--env SPLUNK_CMD='edit user admin -password random_password -role
         admin -auth admin:changeme'`.
+- `SPLUNK_START_ARGS='--accept-license"` - Splunk requires you to accept the
+  license, I (maintainer of this image) don't want do that for you, so please
+  add this on your own or start container with `-it` switch.
 
 #### Example
 
@@ -194,6 +197,7 @@ configuration files or deployment server.
     --name splunkdeploymentserver \
     --publish 8000 \
     --env SPLUNK_ENABLE_DEPLOY_SERVER=true \
+    --env SPLUNK_START_ARGS="--accept-license" \
     outcoldman/splunk
 > echo "Starting indexer 1"
 > docker run -d --net splunk \
@@ -201,6 +205,7 @@ configuration files or deployment server.
     --name splunkindexer1 \
     --publish 8000 \
     --env SPLUNK_ENABLE_LISTEN=9997 \
+    --env SPLUNK_START_ARGS="--accept-license" \
     outcoldman/splunk
 > echo "Starging indexer 2"
 > docker run --rm --net splunk \
@@ -208,6 +213,7 @@ configuration files or deployment server.
     --name splunkindexer2 \
     --publish 8000 \
     --env SPLUNK_ENABLE_LISTEN=9997 \
+    --env SPLUNK_START_ARGS="--accept-license" \
     outcoldman/splunk
 > echo "Starting forwarder, which forwards data to 2 indexers by cloning events"
 > docker run -d --net splunk \
@@ -219,6 +225,7 @@ configuration files or deployment server.
     --env SPLUNK_FORWARD_SERVER_1_ARGS="-method clone" \
     --env SPLUNK_ADD='udp 1514' \
     --env SPLUNK_DEPLOYMENT_SERVER='splunkdeploymentserver:8089' \
+    --env SPLUNK_START_ARGS="--accept-license" \
     outcoldman/splunk:forwarder
 ```
 
@@ -235,11 +242,11 @@ Upgrade example below
 # Use data volume container to persist data between upgrades
 docker run --name vsplunk -v /opt/splunk/etc -v /opt/splunk/var busybox
 # Start old version of Splunk Enterprise
-docker run --hostname splunk --name splunk --volumes-from=vsplunk -p 8000:8000 -d outcoldman/splunk:6.3.3
+docker run --hostname splunk --name splunk --volumes-from=vsplunk -p 8000:8000 -d --env SPLUNK_START_ARGS="--accept-license" outcoldman/splunk:6.3.3
 # Stop Splunk Enterprise container
 docker stop splunk
 # Remove Splunk Enterprise container
 docker rm -v splunk
 # Start Splunk Enterprise container with new version
-docker run --hostname splunk --name splunk --volumes-from=vsplunk -p 8000:8000 -d outcoldman/splunk:6.4.0
+docker run --hostname splunk --name splunk --volumes-from=vsplunk -p 8000:8000 -d --env SPLUNK_START_ARGS="--accept-license" outcoldman/splunk:6.4.0
 ```

--- a/splunk/Dockerfile
+++ b/splunk/Dockerfile
@@ -26,7 +26,7 @@ RUN apt-get install -y libgssapi-krb5-2
 
 # Download official Splunk release, verify checksum and unzip in /opt/splunk
 # Also backup etc folder, so it will be later copied to the linked volume
-RUN apt-get install -y wget \
+RUN apt-get install -y wget sudo \
     && mkdir -p ${SPLUNK_HOME} \
     && wget -qO /tmp/${SPLUNK_FILENAME} https://download.splunk.com/products/${SPLUNK_PRODUCT}/releases/${SPLUNK_VERSION}/linux/${SPLUNK_FILENAME} \
     && wget -qO /tmp/${SPLUNK_FILENAME}.md5 https://download.splunk.com/products/${SPLUNK_PRODUCT}/releases/${SPLUNK_VERSION}/linux/${SPLUNK_FILENAME}.md5 \

--- a/splunk/Dockerfile
+++ b/splunk/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:trusty
+FROM debian:jessie
 
 MAINTAINER Denis Gladkikh <docker-splunk@denis.gladkikh.email>
 

--- a/splunk/entrypoint.sh
+++ b/splunk/entrypoint.sh
@@ -17,15 +17,33 @@ elif [ "$1" = 'start-service' ]; then
     __configured=true
   fi
 
+  __license_ok=false
   # If these files are different override etc folder (possible that this is upgrade or first start cases)
   # Also override ownership of these files to splunk:splunk
   if ! $(cmp --silent /var/opt/splunk/etc/splunk.version ${SPLUNK_HOME}/etc/splunk.version); then
     cp -fR /var/opt/splunk/etc ${SPLUNK_HOME}
     chown -R ${SPLUNK_USER}:${SPLUNK_GROUP} ${SPLUNK_HOME}/etc
     chown -R ${SPLUNK_USER}:${SPLUNK_GROUP} ${SPLUNK_HOME}/var
+  else
+    __license_ok=true
   fi
 
-  sudo -HEu ${SPLUNK_USER} ${SPLUNK_HOME}/bin/splunk start --accept-license --answer-yes --no-prompt
+  if tty -s; then
+    __license_ok=true
+  fi
+
+  if [[ "$SPLUNK_START_ARGS" == *"--accept-license"* ]]; then
+    __license_ok=true
+  fi
+
+  if [[ $__license_ok == "false" ]]; then
+    echo "It seems like that this is the first time you are running this container."
+    echo "You need to run this container with TTY support (just add a -it switch) to accept the license."
+    echo "Or start container with environment variable SPLUNK_START_ARGS=--accept-license."
+    exit 1
+  fi
+
+  sudo -HEu ${SPLUNK_USER} ${SPLUNK_HOME}/bin/splunk start ${SPLUNK_START_ARGS}
   trap "sudo -HEu ${SPLUNK_USER} ${SPLUNK_HOME}/bin/splunk stop" SIGINT SIGTERM EXIT
 
   # If this is first time we start this splunk instance

--- a/splunk/entrypoint.sh
+++ b/splunk/entrypoint.sh
@@ -37,9 +37,24 @@ elif [ "$1" = 'start-service' ]; then
   fi
 
   if [[ $__license_ok == "false" ]]; then
-    echo "It seems like that this is the first time you are running this container."
-    echo "You need to run this container with TTY support (just add a -it switch) to accept the license."
-    echo "Or start container with environment variable SPLUNK_START_ARGS=--accept-license."
+    cat << EOF
+Splunk Enterprise
+==============
+
+  Available Options:
+
+      - Launch container in Interactive mode "-it" to review and accept
+        end user license agreement
+      - If you have reviewed and accepted the license, start container
+        with the environment variable:
+            SPLUNK_START_ARGS=--accept-license
+
+  Usage:
+
+    docker run -it outcoldman/splunk:latest
+    docker run --env SPLUNK_START_ARGS="--accept-license" outcoldman/splunk:latest
+
+EOF
     exit 1
   fi
 

--- a/splunklight/Dockerfile
+++ b/splunklight/Dockerfile
@@ -26,7 +26,7 @@ RUN apt-get install -y libgssapi-krb5-2
 
 # Download official Splunk release, verify checksum and unzip in /opt/splunk
 # Also backup etc folder, so it will be later copied to the linked volume
-RUN apt-get install -y wget \
+RUN apt-get install -y wget sudo \
     && mkdir -p ${SPLUNK_HOME} \
     && wget -qO /tmp/${SPLUNK_FILENAME} https://download.splunk.com/products/${SPLUNK_PRODUCT}/releases/${SPLUNK_VERSION}/linux/${SPLUNK_FILENAME} \
     && wget -qO /tmp/${SPLUNK_FILENAME}.md5 https://download.splunk.com/products/${SPLUNK_PRODUCT}/releases/${SPLUNK_VERSION}/linux/${SPLUNK_FILENAME}.md5 \

--- a/splunklight/Dockerfile
+++ b/splunklight/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:trusty
+FROM debian:jessie
 
 MAINTAINER Denis Gladkikh <docker-splunk@denis.gladkikh.email>
 

--- a/splunklight/entrypoint.sh
+++ b/splunklight/entrypoint.sh
@@ -37,9 +37,24 @@ elif [ "$1" = 'start-service' ]; then
   fi
 
   if [[ $__license_ok == "false" ]]; then
-    echo "It seems like that this is the first time you are running this container."
-    echo "You need to run this container with TTY support (just add a -it switch) to accept the license."
-    echo "Or start container with environment variable SPLUNK_START_ARGS=--accept-license."
+    cat << EOF
+Splunk Enterprise
+==============
+
+  Available Options:
+
+      - Launch container in Interactive mode "-it" to review and accept
+        end user license agreement
+      - If you have reviewed and accepted the license, start container
+        with the environment variable:
+            SPLUNK_START_ARGS=--accept-license
+
+  Usage:
+
+    docker run -it outcoldman/splunk:latest
+    docker run --env SPLUNK_START_ARGS="--accept-license" outcoldman/splunk:latest
+
+EOF
     exit 1
   fi
 

--- a/splunklight/entrypoint.sh
+++ b/splunklight/entrypoint.sh
@@ -17,15 +17,33 @@ elif [ "$1" = 'start-service' ]; then
     __configured=true
   fi
 
+  __license_ok=false
   # If these files are different override etc folder (possible that this is upgrade or first start cases)
   # Also override ownership of these files to splunk:splunk
   if ! $(cmp --silent /var/opt/splunk/etc/splunk.version ${SPLUNK_HOME}/etc/splunk.version); then
     cp -fR /var/opt/splunk/etc ${SPLUNK_HOME}
     chown -R ${SPLUNK_USER}:${SPLUNK_GROUP} $SPLUNK_HOME/etc
     chown -R ${SPLUNK_USER}:${SPLUNK_GROUP} $SPLUNK_HOME/var
+  else
+    __license_ok=true
   fi
 
-  sudo -HEu ${SPLUNK_USER} ${SPLUNK_HOME}/bin/splunk start --accept-license --answer-yes --no-prompt
+  if tty -s; then
+    __license_ok=true
+  fi
+
+  if [[ "$SPLUNK_START_ARGS" == *"--accept-license"* ]]; then
+    __license_ok=true
+  fi
+
+  if [[ $__license_ok == "false" ]]; then
+    echo "It seems like that this is the first time you are running this container."
+    echo "You need to run this container with TTY support (just add a -it switch) to accept the license."
+    echo "Or start container with environment variable SPLUNK_START_ARGS=--accept-license."
+    exit 1
+  fi
+
+  sudo -HEu ${SPLUNK_USER} ${SPLUNK_HOME}/bin/splunk start ${SPLUNK_START_ARGS}
   trap "sudo -HEu ${SPLUNK_USER} ${SPLUNK_HOME}/bin/splunk stop" SIGINT SIGTERM EXIT
 
   # If this is first time we start this splunk instance

--- a/universalforwarder/Dockerfile
+++ b/universalforwarder/Dockerfile
@@ -23,7 +23,7 @@ ENV LANG en_US.utf8
 
 # Download official Splunk release, verify checksum and unzip in /opt/splunk
 # Also backup etc folder, so it will be later copied to the linked volume
-RUN apt-get install -y wget \
+RUN apt-get install -y wget sudo \
     && mkdir -p ${SPLUNK_HOME} \
     && wget -qO /tmp/${SPLUNK_FILENAME} https://download.splunk.com/products/${SPLUNK_PRODUCT}/releases/${SPLUNK_VERSION}/linux/${SPLUNK_FILENAME} \
     && wget -qO /tmp/${SPLUNK_FILENAME}.md5 https://download.splunk.com/products/${SPLUNK_PRODUCT}/releases/${SPLUNK_VERSION}/linux/${SPLUNK_FILENAME}.md5 \

--- a/universalforwarder/Dockerfile
+++ b/universalforwarder/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:trusty
+FROM debian:jessie
 
 MAINTAINER Denis Gladkikh <docker-splunk@denis.gladkikh.email>
 

--- a/universalforwarder/entrypoint.sh
+++ b/universalforwarder/entrypoint.sh
@@ -37,9 +37,24 @@ elif [ "$1" = 'start-service' ]; then
   fi
 
   if [[ $__license_ok == "false" ]]; then
-    echo "It seems like that this is the first time you are running this container."
-    echo "You need to run this container with TTY support (just add a -it switch) to accept the license."
-    echo "Or start container with environment variable SPLUNK_START_ARGS=--accept-license."
+    cat << EOF
+Splunk Enterprise
+==============
+
+  Available Options:
+
+      - Launch container in Interactive mode "-it" to review and accept
+        end user license agreement
+      - If you have reviewed and accepted the license, start container
+        with the environment variable:
+            SPLUNK_START_ARGS=--accept-license
+
+  Usage:
+
+    docker run -it outcoldman/splunk:latest
+    docker run --env SPLUNK_START_ARGS="--accept-license" outcoldman/splunk:latest
+
+EOF
     exit 1
   fi
 

--- a/universalforwarder/entrypoint.sh
+++ b/universalforwarder/entrypoint.sh
@@ -17,15 +17,33 @@ elif [ "$1" = 'start-service' ]; then
     __configured=true
   fi
 
+  __license_ok=false
   # If these files are different override etc folder (possible that this is upgrade or first start cases)
   # Also override ownership of these files to splunk:splunk
   if ! $(cmp --silent /var/opt/splunk/etc/splunk.version ${SPLUNK_HOME}/etc/splunk.version); then
     cp -fR /var/opt/splunk/etc ${SPLUNK_HOME}
     chown -R ${SPLUNK_USER}:${SPLUNK_GROUP} $SPLUNK_HOME/etc
     chown -R ${SPLUNK_USER}:${SPLUNK_GROUP} $SPLUNK_HOME/var
+  else
+    __license_ok=true
   fi
 
-  sudo -HEu ${SPLUNK_USER} ${SPLUNK_HOME}/bin/splunk start --accept-license --answer-yes --no-prompt
+  if tty -s; then
+    __license_ok=true
+  fi
+
+  if [[ "$SPLUNK_START_ARGS" == *"--accept-license"* ]]; then
+    __license_ok=true
+  fi
+
+  if [[ $__license_ok == "false" ]]; then
+    echo "It seems like that this is the first time you are running this container."
+    echo "You need to run this container with TTY support (just add a -it switch) to accept the license."
+    echo "Or start container with environment variable SPLUNK_START_ARGS=--accept-license."
+    exit 1
+  fi
+
+  sudo -HEu ${SPLUNK_USER} ${SPLUNK_HOME}/bin/splunk start ${SPLUNK_START_ARGS}
   trap "sudo -HEu ${SPLUNK_USER} ${SPLUNK_HOME}/bin/splunk stop" SIGINT SIGTERM EXIT
 
   # If this is first time we start this splunk instance


### PR DESCRIPTION
It is not right, that me (maintainer of the image) accept the license
for users.

After that change users will need to add an environment variable
SPLUNK_START_ARGS="--accept-license" or add `-it` switch, so Splunk will
ask user to accept the license.
