### PR TITLE
Fix indexer cluster addressing

### DIFF
--- a/splunk/entrypoint.sh
+++ b/splunk/entrypoint.sh
@@ -117,6 +117,21 @@ EOF
       fi
     done
 
+    # Disable the password rotation UI
+    if [[ -n ${SPLUNK_DISABLE_PW_CHANGE} ]]; then
+        touch ${SPLUNK_HOME}/etc/.ui_login
+    fi
+
+    # Fix replication addresses
+    if [[ -n ${SPLUNK_FIX_DOCKER_REP_ADDR} ]]; then
+      if [[ -z `grep -o "clustering" "${SPLUNK_HOME}/etc/system/local/server.conf"` ]]; then
+        echo "[clustering]" >> "${SPLUNK_HOME}/etc/system/local/server.conf"
+      fi
+      IP=`/sbin/ip route|awk '/scope/ { print $9 }'` && sed -i '/\[clustering\]/a register_search_address = '$IP "${SPLUNK_HOME}/etc/system/local/server.conf"
+      IP=`/sbin/ip route|awk '/scope/ { print $9 }'` && sed -i '/\[clustering\]/a register_forwarder_address = '$IP "${SPLUNK_HOME}/etc/system/local/server.conf"
+      IP=`/sbin/ip route|awk '/scope/ { print $9 }'` && sed -i '/\[clustering\]/a register_replication_address = '$IP "${SPLUNK_HOME}/etc/system/local/server.conf"
+    fi
+
     # Execute anything
     if [[ -n ${SPLUNK_CMD} ]]; then
         sudo -HEu ${SPLUNK_USER} sh -c "${SPLUNK_HOME}/bin/splunk ${SPLUNK_CMD}"


### PR DESCRIPTION
I have been running into issues using an indexer cluster, it appears to be a odd docker / splunk networking bug where indexers advertise their replication address as the deployment server / master address leading to a broken cluster.

Added two flags additional flags to entrypoint.sh
- SPLUNK_FIX_DOCKER_REP_ADDR
  
    Sets the replication address to the containers internal IP for clustering stanza
- SPLUNK_DISABLE_PW_CHANGE
  
    Since I am testing REST endpoint things I already change the splunk admin password. Bouncing through the confirm UI is really annoying.
