### PR TITLE
Splunk 6.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@
 
 Current branch:
 
-* `6.4`, `6.4.3`, `latest` - Splunk Enterprise
-* `6.4-light`, `6.4.3-light`, `latest-light` - Splunk Light
-* `6.4-forwarder`, `6.4.3-forwarder`, `latest-forwarder` - Splunk Universal Forwarder
+* `6.5`, `6.5.0`, `latest` - Splunk Enterprise
+* `6.5-light`, `6.5.0-light`, `latest-light` - Splunk Light
+* `6.5-forwarder`, `6.5.0-forwarder`, `latest-forwarder` - Splunk Universal Forwarder
 
 For previous versions or newest releases see other branches.
 

--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ Dockerfiles to build [Splunk](https://splunk.com) including Enterpise, Light and
 
 ### Version
 
-* Version: `6.4.3`
-* Build: `b03109c2bad4`
+* Version: `6.5.0`
+* Build: `59c8927def0f`
 
 ## Installation
 
@@ -58,14 +58,14 @@ docker build --tag="$USER/splunk" .
 To manually start Splunk Enterprise container 
 
 ```bash
-docker run --hostname splunk -p 8000:8000 -d --env SPLUNK_START_ARGS="--accept-license --answer-yes --no-prompt" outcoldman/splunk:6.4.3
+docker run --hostname splunk -p 8000:8000 -d --env SPLUNK_START_ARGS="--accept-license --answer-yes --no-prompt" outcoldman/splunk:6.5.0
 ```
 
 This docker image has two data volumes `/opt/splunk/etc` and `/opt/splunk/var` (See [Data Store](#data-store)). To avoid losing any data when container is stopped/deleted mount these volumes from docker volume containers (see [Managing data in containers](https://docs.docker.com/userguide/dockervolumes/))
 
 ```bash
 docker run --name vsplunk -v /opt/splunk/etc -v /opt/splunk/var busybox
-docker run --hostname splunk --name splunk --volumes-from=vsplunk -p 8000:8000 -d --env SPLUNK_START_ARGS="--accept-license --answer-yes --no-prompt" outcoldman/splunk:6.4.3
+docker run --hostname splunk --name splunk --volumes-from=vsplunk -p 8000:8000 -d --env SPLUNK_START_ARGS="--accept-license --answer-yes --no-prompt" outcoldman/splunk:6.5.0
 ```
 
 Or if you use [docker-compose](https://docs.docker.com/compose/)
@@ -75,7 +75,7 @@ version: '2'
 services:
 
   splunk:
-    image: outcoldman/splunk:6.4.3
+    image: outcoldman/splunk:6.5.0
     environment: 
       - SPLUNK_START_ARGS=--accept-license --answer-yes --no-prompt
     hostname: splunk
@@ -237,11 +237,11 @@ Upgrade example below
 # Use data volume container to persist data between upgrades
 docker run --name vsplunk -v /opt/splunk/etc -v /opt/splunk/var busybox
 # Start old version of Splunk Enterprise
-docker run --hostname splunk --name splunk --volumes-from=vsplunk -p 8000:8000 -d --env SPLUNK_START_ARGS="--accept-license --answer-yes --no-prompt" outcoldman/splunk:6.4.2
+docker run --hostname splunk --name splunk --volumes-from=vsplunk -p 8000:8000 -d --env SPLUNK_START_ARGS="--accept-license --answer-yes --no-prompt" outcoldman/splunk:6.4.3
 # Stop Splunk Enterprise container
 docker stop splunk
 # Remove Splunk Enterprise container
 docker rm -v splunk
 # Start Splunk Enterprise container with new version
-docker run --hostname splunk --name splunk --volumes-from=vsplunk -p 8000:8000 -d --env SPLUNK_START_ARGS="--accept-license --answer-yes --no-prompt" outcoldman/splunk:6.4.3
+docker run --hostname splunk --name splunk --volumes-from=vsplunk -p 8000:8000 -d --env SPLUNK_START_ARGS="--accept-license --answer-yes --no-prompt" outcoldman/splunk:6.5.0
 ```

--- a/splunk/Dockerfile
+++ b/splunk/Dockerfile
@@ -3,8 +3,8 @@ FROM debian:jessie
 MAINTAINER Denis Gladkikh <docker-splunk@denis.gladkikh.email>
 
 ENV SPLUNK_PRODUCT splunk
-ENV SPLUNK_VERSION 6.4.3
-ENV SPLUNK_BUILD b03109c2bad4
+ENV SPLUNK_VERSION 6.5.0
+ENV SPLUNK_BUILD 59c8927def0f
 ENV SPLUNK_FILENAME splunk-${SPLUNK_VERSION}-${SPLUNK_BUILD}-Linux-x86_64.tgz
 
 ENV SPLUNK_HOME /opt/splunk

--- a/splunklight/Dockerfile
+++ b/splunklight/Dockerfile
@@ -3,8 +3,8 @@ FROM debian:jessie
 MAINTAINER Denis Gladkikh <docker-splunk@denis.gladkikh.email>
 
 ENV SPLUNK_PRODUCT splunk_light
-ENV SPLUNK_VERSION 6.4.3
-ENV SPLUNK_BUILD b03109c2bad4
+ENV SPLUNK_VERSION 6.5.0
+ENV SPLUNK_BUILD 59c8927def0f
 ENV SPLUNK_FILENAME splunklight-${SPLUNK_VERSION}-${SPLUNK_BUILD}-Linux-x86_64.tgz
 
 ENV SPLUNK_HOME /opt/splunk

--- a/universalforwarder/Dockerfile
+++ b/universalforwarder/Dockerfile
@@ -3,8 +3,8 @@ FROM debian:jessie
 MAINTAINER Denis Gladkikh <docker-splunk@denis.gladkikh.email>
 
 ENV SPLUNK_PRODUCT universalforwarder
-ENV SPLUNK_VERSION 6.4.3
-ENV SPLUNK_BUILD b03109c2bad4
+ENV SPLUNK_VERSION 6.5.0
+ENV SPLUNK_BUILD 59c8927def0f
 ENV SPLUNK_FILENAME splunkforwarder-${SPLUNK_VERSION}-${SPLUNK_BUILD}-Linux-x86_64.tgz
 
 ENV SPLUNK_HOME /opt/splunk


### PR DESCRIPTION
Use the newest version (6.5.0) of Splunk Enterprise, Splunk Light and Universal Forwarder
