### PR TITLE
true logs are in splunkd.log (not splunkd_stderr)

### DIFF
--- a/universalforwarder/entrypoint.sh
+++ b/universalforwarder/entrypoint.sh
@@ -134,7 +134,7 @@ EOF
     done
   fi
 
-  sudo -HEu ${SPLUNK_USER} tail -n 0 -f ${SPLUNK_HOME}/var/log/splunk/splunkd_stderr.log &
+  sudo -HEu ${SPLUNK_USER} tail -n 0 -f ${SPLUNK_HOME}/var/log/splunk/splunkd.log &
   wait
 elif [ "$1" = 'splunk-bash' ]; then
   sudo -u ${SPLUNK_USER} /bin/bash --init-file ${SPLUNK_HOME}/bin/setSplunkEnv


### PR DESCRIPTION
I had a heck of a time troubleshooting this container until I modified this in the entrypoint, then I was able to see my config/connection/etc. errors using `docker logs...`.
