### PR TITLE
Fix link to splunk/universalforwarder image

### DIFF
--- a/universalforwarder/README.md
+++ b/universalforwarder/README.md
@@ -111,7 +111,7 @@ You can also use entrypoint.sh to configure Splunk services with environment var
        - /opt/splunk/var
 
     splunkuniversalforwarder:
-     image: splunk/splunkuniversalforwarder:6.5.3-monitor
+     image: splunk/universalforwarder:6.5.3-monitor
      hostname: splunkuniversalforwarder
      environment:
         SPLUNK_START_ARGS: --accept-license --answer-yes

--- a/universalforwarder/docker-compose.yml
+++ b/universalforwarder/docker-compose.yml
@@ -4,7 +4,7 @@
 # Options on how to review the EULA and accept it: 
 # 1. docker run -it splunk/universalforwarder:6.6.2
 # 2. Add the following environment variable: SPLUNK_START_ARGS=--accept-license
-# e.g., docker run -e "SPLUNK_START_ARGS=--accept-license" splunk/splunkuniversalforwarder:6.6.2 
+# e.g., docker run -e "SPLUNK_START_ARGS=--accept-license" splunk/universalforwarder:6.6.2 
 
 version: '3'
 services:


### PR DESCRIPTION
Currently, a couple of points within comments and documentation, path to the universal forwarder image is stated to be 

```
splunk/splunkuniversalforwarder
```

when it's [actually hosted](https://hub.docker.com/r/splunk/universalforwarder/) at 

```
splunk/universalforwarder
```

For awful copy-paste programmers like me who simply took the example `docker-compose.yml` example, there's a lot of head-scratching why the image won't get pulled. 🤷‍♀️

This should fix those issues. 👍

